### PR TITLE
Fix: Replacing broken maven-deluxe with maven

### DIFF
--- a/scripts/opt-in/java-tools.sh
+++ b/scripts/opt-in/java-tools.sh
@@ -2,7 +2,7 @@ echo
 echo "Installing Java Development tools"
 brew install --cask intellij-idea --force # guard against pre-installed intellij
 brew tap jcgay/jcgay
-brew install maven-deluxe
+brew install maven
 brew install gradle
 
 #source ${MY_DIR}/scripts/common/download-jetbrains-ide-prefs.sh


### PR DESCRIPTION
#1 

Simply replaced `maven-deluxe` with `maven`.